### PR TITLE
Pr/16508

### DIFF
--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -392,6 +392,9 @@ class RegularGridInterpolator:
             xi = xi.reshape((1, xi.size))
         m, n = xi.shape
 
+        # number of trailing dimensions of values:
+        n_trailing = values.ndim - n
+
         if method == 'pchip':
             _eval_func = self._do_pchip
         else:
@@ -417,7 +420,13 @@ class RegularGridInterpolator:
             # Main process: Apply 1D interpolate in each dimension
             # sequentially, starting with the last dimension.
             # These are then "folded" into the next dimension in-place.
-            folded_values = first_values[..., j]
+
+            # FIXME : this is a hack
+            if n_trailing == 0:
+                folded_values = first_values[..., j]
+            else:
+                folded_values = first_values[..., j, :]
+
             for i in range(last_dim-1, -1, -1):
                 # Interpolate for each 1D from the last dimensions.
                 # This collapses each 1D sequence into a scalar.

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -707,15 +707,15 @@ class TestInterpN:
         ] * 2
 
         np.random.seed(1234)
-        values = np.random.rand(6, 6, 6, 6, 6)
+        values = np.random.rand(6, 6, 6, 6, 8)
         sample = np.random.rand(7, 11, 4)
 
         v = interpn(points, values, sample, method=method,
                     bounds_error=False)
-        assert_equal(v.shape, (7, 11, 6), err_msg=method)
+        assert_equal(v.shape, (7, 11, 8), err_msg=method)
 
         vs = [interpn(points, values[..., j], sample, method=method,
-                      bounds_error=False) for j in range(6)]
+                      bounds_error=False) for j in range(8)]
         v2 = np.array(vs).transpose(1, 2, 0)
 
         assert_allclose(v, v2, err_msg=method)


### PR DESCRIPTION
Fix up transposing for `values` with trailing axes. Your fixes did the bulk of it, the only thing to take care was trailing dimensions: the RGI code was doing `self.values.T` which reverts the order of axes and thus brings the trailing dimensions (to be broadcast over) to be leading dimensions. Then the iteration over the interpolation dimensions try to interpolate over them which does no good.

The git history here is a bit messy, shows aborted attempts (and I've rebased away a couple more), but in the end it's reasonably simple IMO. 