### PR TITLE
MAINT: stats.variation: add/use temporary xp_copysign

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -413,9 +413,18 @@ def xp_clip(x, a, b, xp=None):
 
 # temporary substitute for xp.moveaxis, which is not yet in all backends
 # or covered by array_api_compat.
-def _move_axis_to_end(x, source, xp=None):
+def xp_moveaxis_to_end(x, source, xp=None):
     xp = array_namespace(xp) if xp is None else xp
     axes = list(range(x.ndim))
     temp = axes.pop(source)
     axes = axes + [temp]
     return xp.permute_dims(x, axes)
+
+
+# temporary substitute for xp.copysign, which is not yet in all backends
+# or covered by array_api_compat.
+def xp_copysign(x1, x2, xp=None):
+    # no attempt to account for special cases
+    xp = array_namespace(x1, x2) if xp is None else xp
+    abs_x1 = xp.abs(x1)
+    return xp.where(x2 >= 0, abs_x1, -abs_x1)

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -9,7 +9,7 @@ import inspect
 
 from scipy._lib._util import check_random_state, _rename_parameter, rng_integers
 from scipy._lib._array_api import (array_namespace, is_numpy, xp_minimum,
-                                   xp_clip, _move_axis_to_end)
+                                   xp_clip, xp_moveaxis_to_end)
 from scipy.special import ndtr, ndtri, comb, factorial
 
 from ._common import ConfidenceInterval
@@ -716,7 +716,7 @@ def _monte_carlo_test_iv(data, rvs, statistic, vectorized, n_resamples,
     data_iv = []
     for sample in data:
         sample = xp.broadcast_to(sample, (1,)) if sample.ndim == 0 else sample
-        sample = _move_axis_to_end(sample, axis_int, xp=xp)
+        sample = xp_moveaxis_to_end(sample, axis_int, xp=xp)
         data_iv.append(sample)
 
     n_resamples_int = int(n_resamples)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -68,7 +68,7 @@ from scipy import stats
 from scipy.optimize import root_scalar
 from scipy._lib._util import normalize_axis_index
 from scipy._lib._array_api import (array_namespace, is_numpy, atleast_nd,
-                                   xp_clip, _move_axis_to_end)
+                                   xp_clip, xp_moveaxis_to_end)
 from scipy._lib.array_api_compat import size as xp_size
 
 # In __all__ but deprecated for removal in SciPy 1.13.0
@@ -4821,8 +4821,8 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
 
     # `moveaxis` only recently added to array API, so it's not yey available in
     # array_api_strict. Replace with e.g. `xp.moveaxis(x, axis, -1)` when available.
-    x = _move_axis_to_end(x, axis, xp)
-    y = _move_axis_to_end(y, axis, xp)
+    x = xp_moveaxis_to_end(x, axis, xp)
+    y = xp_moveaxis_to_end(y, axis, xp)
     axis = -1
 
     dtype = xp.result_type(x.dtype, y.dtype)

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from scipy._lib._util import _get_nan
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import array_namespace, xp_copysign
 
 from ._axis_nan_policy import _axis_nan_policy_factory
 
@@ -118,7 +118,7 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
     if ddof == n:
         # Another special case.  Result is either inf or nan.
         std_a = xp.std(a, axis=axis, correction=0)
-        result = xp.where(std_a > 0, xp.copysign(xp.asarray(xp.inf), mean_a), NaN)
+        result = xp.where(std_a > 0, xp_copysign(xp.asarray(xp.inf), mean_a), NaN)
         return result[()] if result.ndim == 0 else result
 
     with np.errstate(divide='ignore', invalid='ignore'):


### PR DESCRIPTION
#### Reference issue
scipy/scipy#20647

#### What does this implement/fix?
Adds an `xp_copysign` to pass tests with `array_api_strict`.

#### Additional information
I don't expect it to be a big problem for this to ignore the [special cases](https://data-apis.org/array-api/latest/API_specification/generated/array_api.copysign.html), but if you prefer, you can add them or just skip tests with `array_api_strict` until `array_api_compat` adds this.

I also took the opportunity to change the name of `_move_axis_to_end` to something that is more recognizable as a temporary array API function.