### PR TITLE
TST: stats.combine_pvalues: test axis support

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -8042,6 +8042,33 @@ class TestCombinePvalues:
         xp_assert_equal(res.statistic, res[0])
         xp_assert_equal(res.pvalue, res[1])
 
+    @pytest.mark.parametrize("method", methods)
+    # axis=None is currently broken for array API; will be handled when
+    # axis_nan_policy decorator is updated
+    @pytest.mark.parametrize("axis", [0, 1])
+    def test_axis(self, method, axis, xp):
+        rng = np.random.default_rng(234892349810482)
+        x = xp.asarray(rng.random(size=(2, 10)))
+        x = x.T if (axis == 0) else x
+        res = stats.combine_pvalues(x, axis=axis)
+
+        if axis is None:
+            x = xp.reshape(x, (-1,))
+            ref = stats.combine_pvalues(x)
+            xp_assert_close(res.statistic, ref.statistic)
+            xp_assert_close(res.pvalue, ref.pvalue)
+            return
+
+        x = x.T if (axis == 0) else x
+        x0, x1 = x[0, :], x[1, :]
+        ref0 = stats.combine_pvalues(x0)
+        ref1 = stats.combine_pvalues(x1)
+
+        xp_assert_close(res.statistic[0], ref0.statistic)
+        xp_assert_close(res.statistic[1], ref1.statistic)
+        xp_assert_close(res.pvalue[0], ref0.pvalue)
+        xp_assert_close(res.pvalue[1], ref1.pvalue)
+
 
 class TestCdfDistanceValidation:
     """


### PR DESCRIPTION
Adds test of `axis` for all `method`s to gh-20974.

Note that `axis=None` is broken for alternative array backends (but so is `keepdims`, `axis` tuples, etc...). If it's OK with you, let's wait for the decorator to be updated to fix these.