### PR TITLE
MAINT: special.perm: adjustments for backward compatibility/consistency

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2792,25 +2792,24 @@ def perm(N, k, exact=False):
 
     """
     if exact:
+        N = np.squeeze(N)[()]  # for backward compatibility (accepted size 1 arrays)
+        k = np.squeeze(k)[()]
         if not (isscalar(N) and isscalar(k)):
             raise ValueError("`N` and `k` must scalar integers be with `exact=True`.")
+
+        floor_N, floor_k = int(N), int(k)
+        non_integral = not (floor_N == N and floor_k == k)
         if (k > N) or (N < 0) or (k < 0):
-            if (
-                (not isinstance(N, int) and not np.issubdtype(type(N), np.integer))
-                 or (not isinstance(k, int) and not np.issubdtype(type(k), np.integer))
-            ):
+            if non_integral:
                 msg = ("Non-integer `N` and `k` with `exact=True` is deprecated and "
                        "will raise an error in SciPy 1.16.0.")
                 warnings.warn(msg, DeprecationWarning, stacklevel=2)
             return 0
-        if (
-            (not isinstance(N, int) and not np.issubdtype(type(N), np.integer))
-                or (not isinstance(k, int) and not np.issubdtype(type(k), np.integer))
-        ):
+        if non_integral:
             raise ValueError("Non-integer `N` and `k` with `exact=True` is not "
                              "supported.")
         val = 1
-        for i in range(N - k + 1, N + 1):
+        for i in range(floor_N - floor_k + 1, floor_N + 1):
             val *= i
         return val
     else:

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1459,7 +1459,7 @@ class TestCombinatorics:
         assert_equal(special.comb(2, -1, exact=True), 0)
         assert_equal(special.comb(2, -1, exact=False), 0)
         assert_allclose(special.comb([2, -1, 2, 10], [3, 3, -1, 3]), [0., 0., 0., 120.])
-    
+
     def test_comb_exact_non_int_dep(self):
         msg = "`exact=True`"
         with pytest.deprecated_call(match=msg):
@@ -1490,13 +1490,11 @@ class TestCombinatorics:
             special.perm(-4.6, 3, exact=True)
         with pytest.deprecated_call(match="Non-integer"):
             special.perm(4, -3.9, exact=True)
-        
+
         # Non-integral scalars which aren't included in the cases above an raise an
         # error directly without deprecation as this code never worked
         with pytest.raises(ValueError, match="Non-integer"):
             special.perm(6.0, 4.6, exact=True)
-        with pytest.raises(ValueError, match="Non-integer"):
-            special.perm(6.0, 4.0, exact=True)
 
 
 class TestTrigonometric:


### PR DESCRIPTION
#### Reference issue
scipy/scipy#20909

#### What does this implement/fix?
Before scipy/scipy#20909, `perm` accepted lists and arrays as long as `(k > N) or (N < 0) or (k < 0)` worked; scipy/scipy#20909 immediately began to raise an error for non-scalar input. This changes it to be more flexible about the input unless it doesn't make sense (e.g. lists with more than one element and strings no longer work).

Also, scipy/scipy#20909 deprecated integral floats. This reverts that change for consistency with the deprecations made to `comb`. For instance, this still works without warning:
```python3
special.comb(np.asarray([5]), np.asarray(10).reshape(1, 1), exact=True)
```
so this still works without warning
```python3
special.perm(np.asarray([5]), np.asarray(10).reshape(1, 1), exact=True)
```

I don't think this is what we want, ultimately, but I figure that `perm` and `comb` should behave similarly so that a decision about what to do about both can be made together.

Marked as draft because I'd appreciate your thoughts rather than just merging. This is not necessarily correct; it's just trying to bring up some points that might have been overlooked.