### PR TITLE
ENH: differentiate: use xp_take_along_axis

### DIFF
--- a/scipy/differentiate/_differentiate.py
+++ b/scipy/differentiate/_differentiate.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
-from scipy._lib._array_api import array_namespace, xp_sign, xp_copy
+from scipy._lib._array_api import array_namespace, xp_sign, xp_copy, xp_take_along_axis
 
 _EERRORINCREASE = -1  # used in derivative
 
@@ -1096,8 +1096,9 @@ def hessian(f, x, *, tolerances=None, maxiter=10,
     nfev = []  # track inner function evaluations
     res = jacobian(df, x, tolerances=tolerances, **kwargs)  # jacobian of jacobian
 
-    nfev = xp.cumulative_sum(xp.asarray(nfev), axis=0)
-    res.nfev = xp.take_along_axis(nfev, res.nit[xp.newaxis, ...], axis=0)[0]
+    nfev = xp.cumulative_sum(xp.stack(nfev), axis=0)
+    res_nit = xp.astype(res.nit[xp.newaxis, ...], xp.int64)  # appease torch
+    res.nfev = xp_take_along_axis(nfev, res_nit, axis=0)[0]
     res.ddf = res.df
     del res.df  # this is renamed to ddf
     del res.nit  # this is only the outer-jacobian nit


### PR DESCRIPTION
Oops. I remembered we have `xp_take_along_axis`.

#### Reference issue
scipy/scipy#21811