### PR TITLE
Document legacy values for the `btype' parameter

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -566,10 +566,10 @@ stop-band attenuation of :math:`\approx 60` dB.
    >>> import numpy as np
    >>> import scipy.signal as signal
    >>> import matplotlib.pyplot as plt
-
+   ...
    >>> b, a = signal.iirfilter(4, Wn=0.2, rp=5, rs=60, btype='lowpass', ftype='ellip')
    >>> w, h = signal.freqz(b, a)
-
+   ...
    >>> plt.title('Digital filter frequency response')
    >>> plt.plot(w, 20*np.log10(np.abs(h)))
    >>> plt.title('Digital filter frequency response')
@@ -591,7 +591,7 @@ stop-band attenuation of :math:`\approx 60` dB.
         >>> import numpy as np
         >>> from matplotlib import pyplot as plt
         >>> from scipy import signal as sig
-
+        ...
         >>> fs = 16000
         >>> b = sig.firwin(101, 2500, fs=fs)
         >>> f, h_fft = sig.freqz(b, fs=fs)

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2692,6 +2692,13 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='bandpass', analog=False,
         in the stop band. (dB)
     btype : {'bandpass', 'lowpass', 'highpass', 'bandstop'}, optional
         The type of filter.  Default is 'bandpass'.
+        Note that the following legacy aliases should be avoided in new implementations:
+
+        - 'band', 'pass', 'bp' for 'bandpass'
+        - 'l', 'low', 'lp' for 'lowpass'
+        - 'h', 'high', 'hp' for 'highpass'
+        - 'bs', 'bands', 'stop' for 'bandstop'
+
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
@@ -3403,6 +3410,13 @@ def butter(N, Wn, btype='lowpass', analog=False, output='ba', fs=None):
         For analog filters, `Wn` is an angular frequency (e.g. rad/s).
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
         The type of filter.  Default is 'lowpass'.
+        Note that the following legacy aliases should be avoided in new implementations:
+
+        - 'band', 'pass', 'bp' for 'bandpass'
+        - 'l', 'low', 'lp' for 'lowpass'
+        - 'h', 'high', 'hp' for 'highpass'
+        - 'bs', 'bands', 'stop' for 'bandstop'
+
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
@@ -3530,6 +3544,13 @@ def cheby1(N, rp, Wn, btype='lowpass', analog=False, output='ba', fs=None):
         For analog filters, `Wn` is an angular frequency (e.g., rad/s).
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
         The type of filter.  Default is 'lowpass'.
+        Note that the following legacy aliases should be avoided in new implementations:
+
+        - 'band', 'pass', 'bp' for 'bandpass'
+        - 'l', 'low', 'lp' for 'lowpass'
+        - 'h', 'high', 'hp' for 'highpass'
+        - 'bs', 'bands', 'stop' for 'bandstop'
+
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
@@ -3652,6 +3673,13 @@ def cheby2(N, rs, Wn, btype='lowpass', analog=False, output='ba', fs=None):
         For analog filters, `Wn` is an angular frequency (e.g., rad/s).
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
         The type of filter.  Default is 'lowpass'.
+        Note that the following legacy aliases should be avoided in new implementations:
+
+        - 'band', 'pass', 'bp' for 'bandpass'
+        - 'l', 'low', 'lp' for 'lowpass'
+        - 'h', 'high', 'hp' for 'highpass'
+        - 'bs', 'bands', 'stop' for 'bandstop'
+
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
@@ -3771,6 +3799,13 @@ def ellip(N, rp, rs, Wn, btype='lowpass', analog=False, output='ba', fs=None):
         For analog filters, `Wn` is an angular frequency (e.g., rad/s).
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
         The type of filter. Default is 'lowpass'.
+        Note that the following legacy aliases should be avoided in new implementations:
+
+        - 'band', 'pass', 'bp' for 'bandpass'
+        - 'l', 'low', 'lp' for 'lowpass'
+        - 'h', 'high', 'hp' for 'highpass'
+        - 'bs', 'bands', 'stop' for 'bandstop'
+
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
@@ -3893,6 +3928,13 @@ def bessel(N, Wn, btype='lowpass', analog=False, output='ba', norm='phase',
         half-cycles / sample.)
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
         The type of filter.  Default is 'lowpass'.
+        Note that the following legacy aliases should be avoided in new implementations:
+
+        - 'band', 'pass', 'bp' for 'bandpass'
+        - 'l', 'low', 'lp' for 'lowpass'
+        - 'h', 'high', 'hp' for 'highpass'
+        - 'bs', 'bands', 'stop' for 'bandstop'
+
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned. (See Notes.)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1117,7 +1117,7 @@ class TestFreqz:
                               (False, True, 257),
                               (True, False, 257),
                               (True, True, 257)])
-    
+
     @xfail_xp_backends("cupy", reason="XXX: CuPy's version suspect")
     def test_17289(self, whole, nyquist, worN, xp):
         d = xp.asarray([0.0, 1.0])
@@ -4896,7 +4896,8 @@ class TestIIRFilter:
     def test_analog_sos(self, xp):
         # first order Butterworth filter with Wn = 1 has tf 1/(s+1)
         sos = xp.asarray([[0., 0., 1., 0., 1., 1.]])
-        sos2 = iirfilter(N=1, Wn=xp.asarray(1), btype='lowpass', analog=True, output='sos')
+        sos2 = iirfilter(N=1, Wn=xp.asarray(1), btype='lowpass', analog=True,
+                         output='sos')
         assert_array_almost_equal(sos, sos2)
 
     def test_wn1_ge_wn0(self):


### PR DESCRIPTION
To keep the discussion going on how to deal with the `btype` aliases:
What do you think about documenting them as legacy as proposed in this this PR? 
This will make reading old cold bases smoother and we could deprecate them at some later point in time (and merge PR #25146 ).

Furthermore, this PR
* shortens a line in file `test_filter_design.py` to fix the CI Linter error and
* in file `signal.rst`, replace empty lines with `...` in IIR filter examples to make them more copy-and-paste friendly.
